### PR TITLE
better content negotiation

### DIFF
--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -82,6 +82,20 @@ describe('app', () => {
     );
   });
 
+  it('returns jpeg as default content type for any image type', async () => {
+    getObject.mockResolvedValueOnce({
+      Body: jpegBigFixture,
+    });
+
+    await wrap(
+      server
+        .get('/test-file-name/resize/w100')
+        .set('Accept', 'image/*')
+        .expect(200)
+        .expect('Content-Type', /image\/jpeg/),
+    );
+  });
+
   it('returns a webp for complex header', async () => {
     getObject.mockResolvedValueOnce({
       Body: jpegBigFixture,

--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -31,6 +31,30 @@ describe('app', () => {
   });
 
   it('returns 406 if content could not be negotiated', async () => {
+    getObject
+      .mockResolvedValueOnce({
+        Body: jpegBigFixture,
+      })
+      .mockResolvedValueOnce({
+        Body: jpegBigFixture,
+      });
+
+    await wrap(
+      server
+        .get('/test-file-name/resize/w100')
+        .set('Accept', 'text/plain')
+        .expect(406),
+    );
+
+    await wrap(
+      server
+        .get('/test-file-name/resize/w100/png')
+        .set('Accept', 'image/jpeg')
+        .expect(406),
+    );
+  });
+
+  it('returns jpeg as default if accept header is empty', async () => {
     getObject.mockResolvedValueOnce({
       Body: jpegBigFixture,
     });
@@ -38,8 +62,9 @@ describe('app', () => {
     await wrap(
       server
         .get('/test-file-name/resize/w100')
-        .set('Accept', 'text/plain')
-        .expect(406),
+        .set('Accept', '')
+        .expect(200)
+        .expect('Content-Type', /image\/jpeg/),
     );
   });
 

--- a/src/__tests__/parameters.test.ts
+++ b/src/__tests__/parameters.test.ts
@@ -3,7 +3,7 @@ import { getObjectMock } from 'aws-sdk';
 import request from 'supertest';
 import app from '../app';
 import { owlFixture } from './fixtures';
-import { expectResponse, wrap } from './helpers';
+import { expectResponse } from './helpers';
 
 const getObject: jest.Mock = getObjectMock;
 const server = request(app);
@@ -47,16 +47,6 @@ describe('parameters', () => {
       'image/png',
       200,
       true,
-    );
-  });
-
-  it('overrides Accept header using format parameters', async () => {
-    await wrap(
-      server
-        .get('/owl/cover/attention/100x100/webp')
-        .set('Accept', 'image/png')
-        .expect(200)
-        .expect('Content-Type', /image\/webp/),
     );
   });
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -38,15 +38,6 @@ app.use((req, res, next) => {
   return next();
 });
 
-app.use((err, req, res, next) => {
-  console.log(err);
-  if (res.headersSent) {
-    return next(err);
-  }
-  res.status(500);
-  res.render('error', { error: err });
-});
-
 async function processImage(
   image: Buffer,
   {

--- a/src/app.ts
+++ b/src/app.ts
@@ -32,10 +32,19 @@ const defaultS3Params = {
 
 app.use((req, res, next) => {
   if (req.method !== 'GET') {
-    return res.send(405);
+    return res.sendStatus(405);
   }
 
   return next();
+});
+
+app.use((err, req, res, next) => {
+  console.log(err);
+  if (res.headersSent) {
+    return next(err);
+  }
+  res.status(500);
+  res.render('error', { error: err });
 });
 
 async function processImage(
@@ -139,17 +148,34 @@ const manipulator: express.RequestHandler = async (req, res, next) => {
       .promise();
     const cacheControl = 'max-age=31556926, immutable'; // 1 year of immutable
 
-    const requestedContentType =
-      manipulationParameters.format ||
-      (req.accepts([
+    let requestedContentType:
+      | 'image/jpeg'
+      | 'image/png'
+      | 'image/webp'
+      | 'image/svg+xml'
+      | false = false;
+    const forceFormat = manipulationParameters.format;
+
+    // now if force format is set, check if accept headers on request accept it
+    if (forceFormat) {
+      // check if request have proper accept header
+      if (!req.headers.accept || req.accepts(forceFormat)) {
+        requestedContentType = forceFormat;
+      }
+    } else if (!req.headers.accept) {
+      // if request does not have an accept header, treat it as image/jpeg
+      requestedContentType = 'image/jpeg';
+    } else {
+      requestedContentType = req.accepts([
         'image/jpeg',
         'image/png',
         'image/webp',
         'image/svg+xml',
-      ]) as ManipulationParameters['format'] | false);
+      ]) as ManipulationParameters['format'] | false;
+    }
 
     if (requestedContentType === false) {
-      return res.send(406);
+      return res.sendStatus(406);
     }
 
     const parameters: ManipulationParameters = {
@@ -166,9 +192,10 @@ const manipulator: express.RequestHandler = async (req, res, next) => {
 
     return res.send(body);
   } catch (e) {
+    console.log(e);
     if ((e as any).statusCode != null) {
       // @ts-ignore
-      return res.send(e.statusCode, e.message);
+      return res.status(e.statusCode).send(e.message);
     }
 
     return next(e);


### PR DESCRIPTION
If format is in url, compare with `Accept` header
If Accept header is missing treat as `image/jpeg`